### PR TITLE
Make "remove" easier to skim-find keybindings.md

### DIFF
--- a/get-started/keybindings.md
+++ b/get-started/keybindings.md
@@ -4,6 +4,15 @@ To view the current keybindings and change them, click the gear icon in the top 
 
 <figure><img src="../.gitbook/assets/keybindings_settings_button.png" alt=""><figcaption></figcaption></figure>
 
-You can now see all the available commands that you can set a keybinding. You can fuzzy search them by the input box. Click on the row of the command you want to add to change a keybinding. It will have a popup box that shows the name of the command. Simply type in the key you want to bind to the command. Click cancel to cancel the process and save to save the keybinding. To remove a keybinding from a command, simply leave the popup box blank and click save.
+# Finding a Keybinding
+You can now see all the available commands that you can set a keybinding. You can fuzzy search them by the input box.
 
 <figure><img src="../.gitbook/assets/keybindings_settings.png" alt=""><figcaption></figcaption></figure>
+
+# Adding a Keybinding
+Click on the row of the command you want to add to change a keybinding. It will have a popup box that shows the name of the command. Simply type in the key you want to bind to the command.
+
+# Removing/Clearing a Keybinding
+Click on the row, the popup should be empty by default. Clicking `save` while the box is empty will clear the keybinding.
+
+


### PR DESCRIPTION
I read the docs (or I thought I did) for removing a keybinding. Then I searched through issues, then I searched through the discord. Found it on Discord, was going to add it to the docs, and then found it in the docs. So I tried to make it a bit more obvious with this edit.